### PR TITLE
[#48] feat(shared): saga 이벤트 인프라 — DTO·TransactionalEventPublisher·DLQ 추가

### DIFF
--- a/shared/src/main/java/com/commerce/shared/exception/BusinessError.java
+++ b/shared/src/main/java/com/commerce/shared/exception/BusinessError.java
@@ -16,6 +16,7 @@ public enum BusinessError {
     // Order 관련
     INVALID_ORDER_ID("O001", "유효하지 않는 주문 ID"),
     INVALID_ORDER_ITEM_ID("O002", "유효하지 주문건 ID"),
+    INVALID_ORDER_STATUS("O003", "주문 상태 변경이 불가합니다"),
 
     // Quantity 관련
     INVALID_QUANTITY("Q001", "유효하지 않은 수량입니다"),

--- a/shared/src/main/java/com/commerce/shared/kafka/TransactionalEventPublisher.java
+++ b/shared/src/main/java/com/commerce/shared/kafka/TransactionalEventPublisher.java
@@ -1,0 +1,35 @@
+package com.commerce.shared.kafka;
+
+import com.commerce.shared.kafka.event.dto.DomainEvent;
+import com.commerce.shared.kafka.event.topic.EventTopic;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+/**
+ * DB 트랜잭션 커밋 후에만 Kafka 이벤트를 발행한다.
+ * - 트랜잭션 활성 시: afterCommit 콜백으로 등록 -> 롤백 시 발행하지 않음
+ * - 트랜잭션 비활성 시: 즉시 발행 (Consumer에서 이벤트 발행 시)
+ */
+@RequiredArgsConstructor
+@Component
+public class TransactionalEventPublisher {
+
+    private final KafkaEventPublisher kafkaEventPublisher;
+
+    public <T extends DomainEvent> void publish(EventTopic topic, T event) {
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(
+                new TransactionSynchronization() {
+                    @Override
+                    public void afterCommit() {
+                        kafkaEventPublisher.publish(topic, event);
+                    }
+                }
+            );
+        } else {
+            kafkaEventPublisher.publish(topic, event);
+        }
+    }
+}

--- a/shared/src/main/java/com/commerce/shared/kafka/config/KafkaConsumerConfig.java
+++ b/shared/src/main/java/com/commerce/shared/kafka/config/KafkaConsumerConfig.java
@@ -9,7 +9,12 @@ import org.springframework.kafka.annotation.EnableKafka;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.listener.CommonErrorHandler;
 import org.springframework.kafka.listener.ContainerProperties;
+import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
+import org.springframework.kafka.listener.DefaultErrorHandler;
+import org.springframework.util.backoff.FixedBackOff;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -57,18 +62,27 @@ public class KafkaConsumerConfig {
     }
 
     @Bean
-    public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory() {
-        ConcurrentKafkaListenerContainerFactory<String, String> factory = 
+    public CommonErrorHandler kafkaErrorHandler(KafkaTemplate<String, Object> kafkaTemplate) {
+        DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(kafkaTemplate);
+        return new DefaultErrorHandler(recoverer, new FixedBackOff(1000L, 3));
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory(
+            KafkaTemplate<String, Object> kafkaTemplate) {
+        ConcurrentKafkaListenerContainerFactory<String, String> factory =
                 new ConcurrentKafkaListenerContainerFactory<>();
-        
+
         factory.setConsumerFactory(consumerFactory());
-        
+
         // 수동 ACK 모드 (메시지 처리 완료 후 명시적으로 커밋)
         factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.MANUAL);
-        
+
         // 동시 처리 스레드 수
         factory.setConcurrency(3);
-        
+
+        factory.setCommonErrorHandler(kafkaErrorHandler(kafkaTemplate));
+
         return factory;
     }
 }

--- a/shared/src/main/java/com/commerce/shared/kafka/event/dto/CouponAppliedEvent.java
+++ b/shared/src/main/java/com/commerce/shared/kafka/event/dto/CouponAppliedEvent.java
@@ -1,0 +1,11 @@
+package com.commerce.shared.kafka.event.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record CouponAppliedEvent(
+    String orderId, long discountAmt, long originAmt,
+    List<ItemEntry> items, String customerId, String couponId,
+    String payMethod, String payProvider,
+    String key, LocalDateTime timestamp
+) implements DomainEvent { }

--- a/shared/src/main/java/com/commerce/shared/kafka/event/dto/CouponApplyFailedEvent.java
+++ b/shared/src/main/java/com/commerce/shared/kafka/event/dto/CouponApplyFailedEvent.java
@@ -1,0 +1,9 @@
+package com.commerce.shared.kafka.event.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record CouponApplyFailedEvent(
+    String orderId, List<ItemEntry> items, String reason,
+    String key, LocalDateTime timestamp
+) implements DomainEvent { }

--- a/shared/src/main/java/com/commerce/shared/kafka/event/dto/InventoryDeductFailedEvent.java
+++ b/shared/src/main/java/com/commerce/shared/kafka/event/dto/InventoryDeductFailedEvent.java
@@ -1,0 +1,7 @@
+package com.commerce.shared.kafka.event.dto;
+
+import java.time.LocalDateTime;
+
+public record InventoryDeductFailedEvent(
+    String orderId, String reason, String key, LocalDateTime timestamp
+) implements DomainEvent { }

--- a/shared/src/main/java/com/commerce/shared/kafka/event/dto/InventoryDeductedEvent.java
+++ b/shared/src/main/java/com/commerce/shared/kafka/event/dto/InventoryDeductedEvent.java
@@ -1,0 +1,10 @@
+package com.commerce.shared.kafka.event.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record InventoryDeductedEvent(
+    String orderId, String customerId, String couponId,
+    List<ItemEntry> items, String payMethod, String payProvider,
+    String key, LocalDateTime timestamp
+) implements DomainEvent { }

--- a/shared/src/main/java/com/commerce/shared/kafka/event/dto/ItemEntry.java
+++ b/shared/src/main/java/com/commerce/shared/kafka/event/dto/ItemEntry.java
@@ -1,0 +1,3 @@
+package com.commerce.shared.kafka.event.dto;
+
+public record ItemEntry(String productId, long quantity) { }

--- a/shared/src/main/java/com/commerce/shared/kafka/event/dto/OrderCreatedEvent.java
+++ b/shared/src/main/java/com/commerce/shared/kafka/event/dto/OrderCreatedEvent.java
@@ -1,0 +1,10 @@
+package com.commerce.shared.kafka.event.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record OrderCreatedEvent(
+    String orderId, String customerId, String couponId,
+    List<ItemEntry> items, String payMethod, String payProvider,
+    String key, LocalDateTime timestamp
+) implements DomainEvent { }

--- a/shared/src/main/java/com/commerce/shared/kafka/event/dto/OrderPriceFailedEvent.java
+++ b/shared/src/main/java/com/commerce/shared/kafka/event/dto/OrderPriceFailedEvent.java
@@ -1,0 +1,9 @@
+package com.commerce.shared.kafka.event.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record OrderPriceFailedEvent(
+    String orderId, List<ItemEntry> items, String reason,
+    String key, LocalDateTime timestamp
+) implements DomainEvent { }

--- a/shared/src/main/java/com/commerce/shared/kafka/event/dto/OrderPricedEvent.java
+++ b/shared/src/main/java/com/commerce/shared/kafka/event/dto/OrderPricedEvent.java
@@ -1,0 +1,10 @@
+package com.commerce.shared.kafka.event.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record OrderPricedEvent(
+    String orderId, String customerId, String couponId,
+    long originAmt, List<ItemEntry> items, String payMethod, String payProvider,
+    String key, LocalDateTime timestamp
+) implements DomainEvent { }

--- a/shared/src/main/java/com/commerce/shared/kafka/event/dto/PaymentCompletedEvent.java
+++ b/shared/src/main/java/com/commerce/shared/kafka/event/dto/PaymentCompletedEvent.java
@@ -1,0 +1,8 @@
+package com.commerce.shared.kafka.event.dto;
+
+import java.time.LocalDateTime;
+
+public record PaymentCompletedEvent(
+    String orderId, long originAmt, long discountAmt,
+    String key, LocalDateTime timestamp
+) implements DomainEvent { }

--- a/shared/src/main/java/com/commerce/shared/kafka/event/dto/PaymentFailedEvent.java
+++ b/shared/src/main/java/com/commerce/shared/kafka/event/dto/PaymentFailedEvent.java
@@ -1,0 +1,10 @@
+package com.commerce.shared.kafka.event.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record PaymentFailedEvent(
+    String orderId, String customerId, String couponId,
+    List<ItemEntry> items, String reason,
+    String key, LocalDateTime timestamp
+) implements DomainEvent { }

--- a/shared/src/main/java/com/commerce/shared/kafka/event/dto/SagaTimeoutEvent.java
+++ b/shared/src/main/java/com/commerce/shared/kafka/event/dto/SagaTimeoutEvent.java
@@ -1,0 +1,9 @@
+package com.commerce.shared.kafka.event.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record SagaTimeoutEvent(
+    String orderId, String customerId, String couponId, List<ItemEntry> items,
+    String key, LocalDateTime timestamp
+) implements DomainEvent { }

--- a/shared/src/main/java/com/commerce/shared/kafka/event/topic/EventTopic.java
+++ b/shared/src/main/java/com/commerce/shared/kafka/event/topic/EventTopic.java
@@ -10,7 +10,17 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum EventTopic {
     ORDER_COMPLETED_TOPIC("order.completed"),
-    COUPON_ISSUE_TOPIC("coupon-issue-request")
+    COUPON_ISSUE_TOPIC("coupon-issue-request"),
+    ORDER_CREATED_TOPIC("order.created"),
+    INVENTORY_DEDUCTED_TOPIC("inventory.deducted"),
+    INVENTORY_DEDUCT_FAILED_TOPIC("inventory.deduct-failed"),
+    ORDER_PRICED_TOPIC("order.priced"),
+    ORDER_PRICE_FAILED_TOPIC("order.price-failed"),
+    COUPON_APPLIED_TOPIC("coupon.applied"),
+    COUPON_APPLY_FAILED_TOPIC("coupon.apply-failed"),
+    PAYMENT_COMPLETED_TOPIC("payment.completed"),
+    PAYMENT_FAILED_TOPIC("payment.failed"),
+    SAGA_TIMEOUT_TOPIC("saga.timeout")
     ;
 
     private final String value;

--- a/shared/src/test/java/com/commerce/shared/kafka/TransactionalEventPublisherTest.java
+++ b/shared/src/test/java/com/commerce/shared/kafka/TransactionalEventPublisherTest.java
@@ -1,0 +1,59 @@
+package com.commerce.shared.kafka;
+
+import com.commerce.shared.kafka.event.dto.DomainEvent;
+import com.commerce.shared.kafka.event.topic.EventTopic;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+import java.time.LocalDateTime;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class TransactionalEventPublisherTest {
+
+    @Mock
+    KafkaEventPublisher kafkaEventPublisher;
+
+    @InjectMocks
+    TransactionalEventPublisher transactionalEventPublisher;
+
+    @DisplayName("트랜잭션 활성 시 afterCommit 콜백으로 등록한다")
+    @Test
+    void registerAfterCommitWhenTransactionActive() {
+        TransactionSynchronizationManager.initSynchronization();
+        try {
+            DomainEvent event = new TestEvent("key1", LocalDateTime.now());
+            transactionalEventPublisher.publish(EventTopic.ORDER_CREATED_TOPIC, event);
+            verify(kafkaEventPublisher, never()).publish(any(), any());
+        } finally {
+            TransactionSynchronizationManager.clearSynchronization();
+        }
+    }
+
+    @DisplayName("트랜잭션 롤백 시 이벤트가 발행되지 않는다")
+    @Test
+    void doesNotPublishWhenTransactionRollsBack() {
+        TransactionSynchronizationManager.initSynchronization();
+        try {
+            DomainEvent event = new TestEvent("key1", LocalDateTime.now());
+            transactionalEventPublisher.publish(EventTopic.ORDER_CREATED_TOPIC, event);
+
+            TransactionSynchronizationManager.getSynchronizations().forEach(
+                sync -> sync.afterCompletion(TransactionSynchronization.STATUS_ROLLED_BACK)
+            );
+
+            verify(kafkaEventPublisher, never()).publish(any(), any());
+        } finally {
+            TransactionSynchronizationManager.clearSynchronization();
+        }
+    }
+
+    record TestEvent(String key, LocalDateTime timestamp) implements DomainEvent {}
+}

--- a/shared/src/test/java/com/commerce/shared/kafka/event/dto/EventDtoTest.java
+++ b/shared/src/test/java/com/commerce/shared/kafka/event/dto/EventDtoTest.java
@@ -1,0 +1,39 @@
+package com.commerce.shared.kafka.event.dto;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import java.time.LocalDateTime;
+import java.util.List;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EventDtoTest {
+    @DisplayName("OrderCreatedEvent는 DomainEvent 인터페이스를 구현한다")
+    @Test
+    void orderCreatedEventImplementsDomainEvent() {
+        List<ItemEntry> items = List.of(new ItemEntry("P001", 2));
+        LocalDateTime now = LocalDateTime.now();
+        OrderCreatedEvent event = new OrderCreatedEvent("O001", "C001", null, items, "CARD", "shinHan", "O001", now);
+        assertThat(event).isInstanceOf(DomainEvent.class);
+        assertThat(event.key()).isEqualTo("O001");
+        assertThat(event.timestamp()).isEqualTo(now);
+        assertThat(event.orderId()).isEqualTo("O001");
+        assertThat(event.items()).hasSize(1);
+    }
+
+    @DisplayName("PaymentCompletedEvent는 originAmt와 discountAmt를 포함한다")
+    @Test
+    void paymentCompletedEventContainsAmounts() {
+        LocalDateTime now = LocalDateTime.now();
+        PaymentCompletedEvent event = new PaymentCompletedEvent("O001", 10000, 1000, "O001", now);
+        assertThat(event.originAmt()).isEqualTo(10000);
+        assertThat(event.discountAmt()).isEqualTo(1000);
+    }
+
+    @DisplayName("ItemEntry는 productId와 quantity를 포함한다")
+    @Test
+    void itemEntryContainsFields() {
+        ItemEntry entry = new ItemEntry("P001", 3);
+        assertThat(entry.productId()).isEqualTo("P001");
+        assertThat(entry.quantity()).isEqualTo(3);
+    }
+}


### PR DESCRIPTION
- sagq 체인용 이벤트 DTO 10종(OrderCreated → PaymentCompleted, 보상/타임아웃) 추가
- TransactionalEventPublisher: DB 커밋 후 Kafka 발행(afterCommit 콜백), 비-Tx 컨슈머에서는 즉시 발행                      - KafkaConsumerConfig: DeadLetterPublishingRecoverer + DefaultErrorHandler(1s × 3 retry) 적용                 
-  EventTopic enum: order.created / inventory.* / order.priced / coupon.* / payment.* / saga.timeout 등록